### PR TITLE
fix py3 syntax errors in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import codecs
 import os
 import re
@@ -30,14 +32,14 @@ def find_file(filename, std_dirs, paths):
     # Check the standard locations
     for dir in std_dirs:
         f = os.path.join(dir, filename)
-        print 'looking for', f
+        print('looking for', f)
         if os.path.exists(f):
             return []
 
     # Check the additional directories
     for dir in paths:
         f = os.path.join(dir, filename)
-        print 'looking for', f
+        print('looking for', f)
         if os.path.exists(f):
             return [dir]
 


### PR DESCRIPTION
**Bug**: Unhelpful error on attempted install under Python 3.

**Expected behavior**: When attempting to install under Python 3, the user sees an error indicating they already have it installed. (Note that this happens, correctly, when attempting to install under Python 2.6+.)

**Actual behavior**: `setup.py` fails with a `SyntaxError`:

```
$ python --version
Python 3.6.0
$ git rev-parse --abbrev-ref HEAD
master
$ pip install .
Processing /home/mambocab/cstar_src/ssl
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-i70f75bv-build/setup.py", line 33
        print 'looking for', f
                          ^
    SyntaxError: Missing parentheses in call to 'print'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-i70f75bv-build/
```

------

We've had some users confused by this error, and it looks like you've recieved some erroneous error reports about it as well (#2, #7).

This PR brings installation behavior in line with the installation behavior under Python 2.6+:

```
$ python --version
Python 3.6.0
$ git rev-parse --abbrev-ref HEAD
error-reporting
$ pip install .
Processing /home/mambocab/cstar_src/ssl
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-149_ydsx-build/setup.py", line 14, in <module>
        + "or earlier.")
    ValueError: This extension should not be used with Python 2.6 or later (already built in), and has not been tested with Python 2.3.4 or earlier.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-149_ydsx-build/
```